### PR TITLE
Update instance_template_creator_configs.py

### DIFF
--- a/scripts/configs/infrastructure/instance_template_creator_configs.py
+++ b/scripts/configs/infrastructure/instance_template_creator_configs.py
@@ -26,7 +26,7 @@ class VMMetaDataConfig:
     python_hash_seed: int = 442
     mlflow_tracking_uri: str = SI("${infrastructure.mlflow.mlflow_internal_tracking_uri}")
     node_count: int = SI("${infrastructure.instance_group_creator.node_count}")
-    disks: list[str] = SI("${..vmconfig.disks}")  
+    disks: list[str] = SI("${..vm_config.disks}")  
 
 @dataclass
 class InstanceTemplateCreatorConfig:


### PR DESCRIPTION
Here is an error I found.

In the `InstanceTemplateCreatorConfig` class, this key is defined as `vm_config`, so it should also be referenced the same.